### PR TITLE
Add metrics middleware to Alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
@@ -664,9 +665,11 @@ dependencies = [
  "alloy",
  "async-trait",
  "color-eyre",
+ "prometheus",
  "serde",
  "serde_json",
  "tokio",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2675,6 +2678,7 @@ dependencies = [
  "mockall",
  "molecule_ipnft",
  "pretty_assertions",
+ "prometheus",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ alloy_ext = { path = "src/utils/alloy_ext", default-features = false }
 alloy = { version = "1", default-features = false, features = [
     "std",
     "contract",
+    "json-rpc",
     "network",
     "provider-http",
     "provider-ws",
@@ -72,6 +73,7 @@ tokio = { version = "1", default-features = false, features = [
     "macros",
     "signal",
 ] }
+tower = { version = "0.5", default-features = false }
 
 
 [workspace.package]

--- a/src/app/bridge/src/metrics.rs
+++ b/src/app/bridge/src/metrics.rs
@@ -1,5 +1,8 @@
 pub struct BridgeMetrics {
-    pub rpc_queries_num: prometheus::IntCounter,
+    pub evm_rpc_requests_num_total: prometheus::IntCounter,
+    pub evm_rpc_errors_num_total: prometheus::IntCounter,
+    pub kamu_gql_requests_num_total: prometheus::IntCounter,
+    pub kamu_gql_errors_num_total: prometheus::IntCounter,
 }
 
 impl BridgeMetrics {
@@ -7,16 +10,40 @@ impl BridgeMetrics {
         use prometheus::*;
 
         Self {
-            rpc_queries_num: IntCounter::with_opts(
-                Opts::new("rpc_queries_num", "Blockchain node RPC queries executed")
-                    .const_label("chain_id", chain_id.to_string()),
+            evm_rpc_requests_num_total: IntCounter::with_opts(
+                Opts::new(
+                    "evm_rpc_requests_num_total",
+                    "Number of EVM node RPC requests executed",
+                )
+                .const_label("chain_id", chain_id.to_string()),
             )
+            .unwrap(),
+            evm_rpc_errors_num_total: IntCounter::with_opts(
+                Opts::new(
+                    "evm_rpc_errors_num_total",
+                    "Number of EVM node RPC requests that resulted in an error",
+                )
+                .const_label("chain_id", chain_id.to_string()),
+            )
+            .unwrap(),
+            kamu_gql_requests_num_total: IntCounter::with_opts(Opts::new(
+                "kamu_gql_requests_num_total",
+                "Number of GQL requests executed on Kamu Node",
+            ))
+            .unwrap(),
+            kamu_gql_errors_num_total: IntCounter::with_opts(Opts::new(
+                "kamu_gql_errors_num_total",
+                "Number of GQL requests executed on Kamu Node that resulted in an error",
+            ))
             .unwrap(),
         }
     }
 
     pub fn register(&self, reg: &prometheus::Registry) -> Result<(), prometheus::Error> {
-        reg.register(Box::new(self.rpc_queries_num.clone()))?;
+        reg.register(Box::new(self.evm_rpc_requests_num_total.clone()))?;
+        reg.register(Box::new(self.evm_rpc_errors_num_total.clone()))?;
+        reg.register(Box::new(self.kamu_gql_requests_num_total.clone()))?;
+        reg.register(Box::new(self.kamu_gql_errors_num_total.clone()))?;
         Ok(())
     }
 }

--- a/src/domain/kamu_node_api_client/Cargo.toml
+++ b/src/domain/kamu_node_api_client/Cargo.toml
@@ -33,12 +33,15 @@ async-trait = { workspace = true }
 # TODO: use just eyre and color-eyre only in main.rs
 color-eyre = { workspace = true }
 indoc = { workspace = true }
+prometheus = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 
-graphql_client = { version = "0.14.0", default-features = false, features = ["graphql_query_derive"] }
+graphql_client = { version = "0.14.0", default-features = false, features = [
+    "graphql_query_derive",
+] }
 
 mockall = { optional = true, workspace = true }
 

--- a/src/utils/alloy_ext/Cargo.toml
+++ b/src/utils/alloy_ext/Cargo.toml
@@ -26,10 +26,12 @@ default = []
 
 [dependencies]
 alloy = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tower = { workspace = true }
 
 async-trait = { workspace = true }
 color-eyre = { workspace = true }

--- a/src/utils/alloy_ext/src/lib.rs
+++ b/src/utils/alloy_ext/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod log_ext;
+pub mod metrics;
 pub mod prelude;
 pub mod provider_ext;
+pub mod tracing;

--- a/src/utils/alloy_ext/src/metrics.rs
+++ b/src/utils/alloy_ext/src/metrics.rs
@@ -1,0 +1,82 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use alloy::{
+    rpc::json_rpc::{RequestPacket, ResponsePacket},
+    transports::TransportError,
+};
+use tower::{Layer, Service};
+
+pub struct MetricsLayer {
+    metric_requests_num_total: prometheus::IntCounter,
+    metric_errors_num_total: prometheus::IntCounter,
+}
+
+impl MetricsLayer {
+    pub fn new(
+        metric_requests_num_total: prometheus::IntCounter,
+        metric_errors_num_total: prometheus::IntCounter,
+    ) -> Self {
+        Self {
+            metric_requests_num_total,
+            metric_errors_num_total,
+        }
+    }
+}
+
+// A tower::Layer that reports Prometheus metrics for RPC calls.
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService {
+            inner,
+            metric_requests_num_total: self.metric_requests_num_total.clone(),
+            metric_errors_num_total: self.metric_errors_num_total.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+    metric_requests_num_total: prometheus::IntCounter,
+    metric_errors_num_total: prometheus::IntCounter,
+}
+
+impl<S> Service<RequestPacket> for MetricsService<S>
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>,
+    S::Future: Send + 'static,
+    S::Response: Send + 'static + Debug,
+    S::Error: Send + 'static + Debug,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        self.metric_requests_num_total.inc();
+
+        let fut = self.inner.call(req);
+        let metric_errors_num_total = self.metric_errors_num_total.clone();
+
+        Box::pin(async move {
+            match fut.await {
+                Ok(res) => Ok(res),
+                Err(err) => {
+                    metric_errors_num_total.inc();
+                    Err(err)
+                }
+            }
+        })
+    }
+}

--- a/src/utils/alloy_ext/src/tracing.rs
+++ b/src/utils/alloy_ext/src/tracing.rs
@@ -1,0 +1,51 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use alloy::{
+    rpc::json_rpc::{RequestPacket, ResponsePacket},
+    transports::TransportError,
+};
+use tower::{Layer, Service};
+use tracing::Instrument;
+
+pub struct TracingLayer;
+
+// A tower::Layer that wraps RPC calls with debug `EvmRpc::request` spans.
+impl<S> Layer<S> for TracingLayer {
+    type Service = TracingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TracingService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TracingService<S> {
+    inner: S,
+}
+
+impl<S> Service<RequestPacket> for TracingService<S>
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>,
+    S::Future: Send + 'static,
+    S::Response: Send + 'static + Debug,
+    S::Error: Send + 'static + Debug,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        let span = tracing::debug_span!("EvmRpc::request");
+
+        Box::pin(self.inner.call(req).instrument(span))
+    }
+}


### PR DESCRIPTION
This PR integrates metrics with alloy on tower middleware layer.

Unfortunately due to alloy's architecture we only have two choices in layering:
- Transport layer with `tower`
  - low level and captures all RPC calls
  - but only has access to serialized request from which it would be inefficient to extract the RPC method name
- Provider wrapping
  - has knowledge of which RPC calls are made
  - but involves re-implementing a lot of methods e.g. `get_chain_id`, `get_logs` separately
  - and may not equal the number of actual calls due to retries on transport level

So for now I chose `tower` layer without reporting endpoint names, but we can extend in future.

Along the way I added similar metrics for Kamu GQL calls (without middleware for now). And also added tracing middleware to node RPC calls.

Sample of output metrics:
```
# HELP kamu_molecule_bridge_evm_rpc_errors_num_total Number of EVM node RPC requests that resulted in an error
# TYPE kamu_molecule_bridge_evm_rpc_errors_num_total counter
kamu_molecule_bridge_evm_rpc_errors_num_total{chain_id="1"} 0
# HELP kamu_molecule_bridge_evm_rpc_requests_num_total Number of EVM node RPC requests executed
# TYPE kamu_molecule_bridge_evm_rpc_requests_num_total counter
kamu_molecule_bridge_evm_rpc_requests_num_total{chain_id="1"} 4
# HELP kamu_molecule_bridge_kamu_gql_errors_num_total Number of GQL requests executed on Kamu Node that resulted in an error
# TYPE kamu_molecule_bridge_kamu_gql_errors_num_total counter
kamu_molecule_bridge_kamu_gql_errors_num_total 0
# HELP kamu_molecule_bridge_kamu_gql_requests_num_total Number of GQL requests executed on Kamu Node
# TYPE kamu_molecule_bridge_kamu_gql_requests_num_total counter
kamu_molecule_bridge_kamu_gql_requests_num_total 0
```