### PR TITLE
`molecule_projects_loading_interval_in_secs`: remove extra prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [0.2.1] - 2025-07-23
+### Fixed
+- Config: `molecule_projects_loading_interval_in_secs`: removed extra prefix.
+
 ## [0.2.0] - 2025-07-23
 ### Added
 - Added a configurable interval for querying project changes during cyclic indexing.

--- a/src/app/bridge/src/app.rs
+++ b/src/app/bridge/src/app.rs
@@ -244,9 +244,7 @@ impl App {
                 .unwrap_or_default();
             (Utc::now() - last_requested_at).num_seconds().try_into()?
         };
-        let interval = self
-            .config
-            .kamu_molecule_bridge_molecule_projects_loading_interval_in_secs;
+        let interval = self.config.molecule_projects_loading_interval_in_secs;
 
         if elapsed_secs >= interval {
             let versioned_file_changes_per_projects =

--- a/src/app/bridge/src/config.rs
+++ b/src/app/bridge/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub molecule_projects_dataset_alias: String,
 
     #[config(env = "KAMU_MOLECULE_BRIDGE_MOLECULE_PROJECTS_LOADING_INTERVAL_IN_SECS")]
-    pub kamu_molecule_bridge_molecule_projects_loading_interval_in_secs: u64,
+    pub molecule_projects_loading_interval_in_secs: u64,
 
     /// ID of the chain that RCP URL is expected to point to
     #[config(env = "KAMU_MOLECULE_BRIDGE_CHAIN_ID")]


### PR DESCRIPTION
## [0.2.1] - 2025-07-23
### Fixed
- Config: `molecule_projects_loading_interval_in_secs`: removed extra prefix.