### PR TITLE
0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [0.5.3] - 2026-01-28
+### Fixed
+- `MoleculeAccessLevel::Holder`: extended to support plural values encountered on testnet.
+
 ## [0.5.2] - 2026-01-28
 ### Changed
 - HTTP: Added exponential backoff on errors (#44).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Recommendation: for ease of reading, use the following order:
 
 ## [0.5.3] - 2026-01-28
 ### Fixed
-- `MoleculeAccessLevel::Holder`: extended to support plural values encountered on testnet.
+- `MoleculeAccessLevel::Holder`: extended to support plural values encountered on testnet (#45).
 
 ## [0.5.2] - 2026-01-28
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "alloy_ext"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-molecule-bridge"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "alloy_ext",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "kamu_node_api_client"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2965,14 +2965,14 @@ dependencies = [
 
 [[package]]
 name = "molecule_contracts"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
 ]
 
 [[package]]
 name = "molecule_ipnft"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "color-eyre",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "multisig"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "multisig_safe_wallet"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "3"
 
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-molecule-bridge"
 repository = "https://github.com/kamu-data/kamu-molecule-bridge"

--- a/src/domain/kamu_node_api_client/src/kamu_node_api_client.rs
+++ b/src/domain/kamu_node_api_client/src/kamu_node_api_client.rs
@@ -114,7 +114,8 @@ pub enum MoleculeAccessLevel {
     Admin,
     #[serde(rename = "admin_2", alias = "ADMIN_2")]
     Admin2,
-    #[serde(alias = "HOLDER")]
+    // NOTE: plural variants only occur for molecule.dev / testnet
+    #[serde(alias = "HOLDER", alias = "holders", alias = "HOLDERS")]
     Holder,
 }
 


### PR DESCRIPTION
## [0.5.3] - 2026-01-28
### Fixed
- `MoleculeAccessLevel::Holder`: extended to support plural values encountered on testnet (#45).